### PR TITLE
Implement support for more chromium-based browsers

### DIFF
--- a/cmd/wsmgr-chrome-rewindow/rewindow.go
+++ b/cmd/wsmgr-chrome-rewindow/rewindow.go
@@ -27,6 +27,20 @@ type bookmarkFile struct {
 	Roots map[string]bookmarkRoot `json:"roots"`
 }
 
+type Browser struct {
+	Executable string
+	ConfigDir  string
+	FlatPak    string
+	flat       bool
+}
+
+var browsers = map[string]Browser{
+	"brave":    {Executable: "brave-browser", ConfigDir: "BraveSoftware/Brave-Browser/Default/Bookmarks", FlatPak: "com.brave.Browser"},
+	"chrome":   {Executable: "google-chrome", ConfigDir: "google-chrome/Default/Bookmarks", FlatPak: "com.google.Chrome"},
+	"chromium": {Executable: "chromium-browser", ConfigDir: "chromium/Default/Bookmarks", FlatPak: "org.chromium.Chromium"},
+	"edge":     {Executable: "msedge", ConfigDir: "microsoft-edge/Default/Bookmarks", FlatPak: "com.microsoft.Edge"},
+}
+
 func inspectChildren(children []Bookmark, f func(Bookmark) bool) bool {
 	for _, ch := range children {
 		if !f(ch) {
@@ -45,32 +59,65 @@ func inspect(root bookmarkRoot, f func(Bookmark) bool) {
 	inspectChildren(root.Children, f)
 }
 
-func openNewWindow(children []Bookmark) {
-	chrome := exec.Command("google-chrome", "--new-window")
-	for _, ch := range children {
-		chrome.Args = append(chrome.Args, ch.URL)
+func (b *Browser) openNewWindow(children []Bookmark) {
+	var cmd *exec.Cmd
+	if b.flat {
+		cmd = exec.Command("flatpak", "run", b.FlatPak, "--new-window")
+	} else {
+		cmd = exec.Command(b.Executable, "--new-window")
 	}
-	log.Printf("%v", chrome)
-	chrome.Stdout = os.Stdout
-	chrome.Stderr = os.Stderr
-	chrome.Stdin = os.Stdin
-	if err := chrome.Run(); err != nil {
+	for _, ch := range children {
+		cmd.Args = append(cmd.Args, ch.URL)
+	}
+	log.Printf("%v", cmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func rewindow() error {
-	var (
-		list = flag.Bool("list", false, "list bookmark folder names")
-		name = flag.String("name", "", "name of the bookmark folder to open in a new window")
-	)
-	flag.Parse()
+func (b *Browser) readFile() ([]byte, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	b, err := ioutil.ReadFile(filepath.Join(configDir, "google-chrome/Default/Bookmarks"))
+	bytes, err := ioutil.ReadFile(filepath.Join(configDir, b.ConfigDir))
+	if err == nil {
+		return bytes, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	b.flat = true
+
+	return ioutil.ReadFile(filepath.Join(homeDir, ".var/app", b.FlatPak, "config", b.ConfigDir))
+}
+
+func rewindow() error {
+	var (
+		list    = flag.Bool("list", false, "list bookmark folder names")
+		browser = flag.String("browser", "google-chrome", "your preferred chromium flavour (default google-chrome)")
+		name    = flag.String("name", "", "name of the bookmark folder to open in a new window")
+	)
+	flag.Parse()
+
+	config, ok := browsers[*browser]
+	if !ok {
+		log.Printf("Supported browsers:")
+		for browser := range browsers {
+			log.Printf("  - %s", browser)
+		}
+		log.Println()
+		log.Fatalf("Browser '%s' not supported (yet, feel free to create a PR)", *browser)
+	}
+
+	b, err := config.readFile()
 	if err != nil {
 		return err
 	}
@@ -98,8 +145,8 @@ func rewindow() error {
 
 	inspect(a.Roots["bookmark_bar"], func(b Bookmark) bool {
 		if b.Type == "folder" && b.Name == *name {
-			log.Printf("opening folder %q in new chrome window", b.Name)
-			openNewWindow(b.Children)
+			log.Printf("opening folder %q in new %s window", b.Name, *browser)
+			config.openNewWindow(b.Children)
 			return false
 		}
 		return true


### PR DESCRIPTION
As I've switched from firefox to chromium today (you cannot install extensions that you built locally, what?!) I wanted to use this part of the package, but then found out that it only supports chrome.

I've added support for all chromium-based browsers that I know and that were readily available via flatpak.
